### PR TITLE
Use test unit gem explicitly

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,5 +2,6 @@ rvm:
   - 1.9.3
   - 2.0.0
   - 2.1.*
+  - 2.2
 gemfile:
   - Gemfile

--- a/fluent-plugin-grepcounter.gemspec
+++ b/fluent-plugin-grepcounter.gemspec
@@ -25,4 +25,5 @@ Gem::Specification.new do |s|
   s.add_development_dependency "pry"
   s.add_development_dependency "pry-nav"
   s.add_development_dependency "coveralls"
+  s.add_development_dependency "test-unit", "~> 3.1.5"
 end


### PR DESCRIPTION
Because Ruby 2.2 does not provide minitest with test-unit compatibility layer.