### PR TITLE
Add config descriptions

### DIFF
--- a/lib/fluent/plugin/out_grepcounter.rb
+++ b/lib/fluent/plugin/out_grepcounter.rb
@@ -19,30 +19,64 @@ class Fluent::GrepCounterOutput < Fluent::Output
     require 'pathname'
   end
 
-  config_param :input_key, :string, :default => nil
-  config_param :regexp, :string, :default => nil
-  config_param :exclude, :string, :default => nil
-  (1..REGEXP_MAX_NUM).each {|i| config_param :"regexp#{i}",  :string, :default => nil }
+  config_param :input_key, :string, :default => nil,
+               :desc => <<-DESC
+The target field key to grep out.
+Use with regexp or exclude.
+DESC
+  config_param :regexp, :string, :default => nil,
+               :desc => 'The filtering regular expression.'
+  config_param :exclude, :string, :default => nil,
+               :desc => 'The excluding regular expression like grep -v.'
+  (1..REGEXP_MAX_NUM).each {|i| config_param :"regexp#{i}", :string, :default => nil }
   (1..REGEXP_MAX_NUM).each {|i| config_param :"exclude#{i}", :string, :default => nil }
-  config_param :count_interval, :time, :default => 5
-  config_param :threshold, :integer, :default => nil # not obsolete, though
+  config_param :count_interval, :time, :default => 5,
+               :desc => 'The interval time to count in seconds.'
+  config_param :threshold, :integer, :default => nil, # not obsolete, though
+               :desc => <<-DESC
+The threshold number to emit.
+Emit if count value >= specified value.
+Note that this param is not obsolete.
+DESC
   config_param :comparator, :string, :default => '>=' # obsolete
-  config_param :less_than, :float, :default => nil
-  config_param :less_equal, :float, :default => nil
-  config_param :greater_than, :float, :default => nil
-  config_param :greater_equal, :float, :default => nil
+  config_param :less_than, :float, :default => nil,
+               :desc => 'Emit if count value is less than (<) specified value.'
+  config_param :less_equal, :float, :default => nil,
+               :desc => 'Emit if count value is less than or equal to (<=) specified value.'
+  config_param :greater_than, :float, :default => nil,
+               :desc => 'Emit if count value is greater than (>) specified value.'
+  config_param :greater_equal, :float, :default => nil,
+               :desc => <<-DESC
+This is same with threshold option.
+Emit if count value is greater than or equal to (>=) specified value.
+DESC
   config_param :output_tag, :string, :default => nil # obsolete
-  config_param :tag, :string, :default => nil
-  config_param :add_tag_prefix, :string, :default => nil
-  config_param :remove_tag_prefix, :string, :default => nil
-  config_param :add_tag_suffix, :string, :default => nil
-  config_param :remove_tag_suffix, :string, :default => nil
-  config_param :remove_tag_slice, :string, :default => nil
+  config_param :tag, :string, :default => nil,
+               :desc => 'The output tag. Required for aggregate all.'
+  config_param :add_tag_prefix, :string, :default => nil,
+               :desc => 'Add tag prefix for output message.'
+  config_param :remove_tag_prefix, :string, :default => nil,
+               :desc => 'Remove tag prefix for output message.'
+  config_param :add_tag_suffix, :string, :default => nil,
+               :desc => 'Add tag suffix for output message.'
+  config_param :remove_tag_suffix, :string, :default => nil,
+               :desc => 'Remove tag suffix for output message.'
+  config_param :remove_tag_slice, :string, :default => nil,
+               :desc => <<-DESC
+Remove tag parts by slice function.
+Note that this option behaves like tag.split('.').slice(min..max).
+DESC
   config_param :output_with_joined_delimiter, :string, :default => nil # obsolete
-  config_param :delimiter, :string, :default => nil
-  config_param :aggregate, :string, :default => 'tag'
-  config_param :replace_invalid_sequence, :bool, :default => false
-  config_param :store_file, :string, :default => nil
+  config_param :delimiter, :string, :default => nil,
+               :desc => 'Output matched messages after joined with the specified delimiter.'
+  config_param :aggregate, :string, :default => 'tag',
+               :desc => 'Aggregation unit. One of all, in_tag, out_tag can be specified.'
+  config_param :replace_invalid_sequence, :bool, :default => false,
+               :desc => "Replace invalid byte sequence in UTF-8 with '?' character if true."
+  config_param :store_file, :string, :default => nil,
+               :desc => <<-DESC
+Store internal count data into a file of the given path on shutdown, and load on statring.
+DESC
 
   attr_accessor :counts
   attr_accessor :matches


### PR DESCRIPTION
`:desc` option fields are shown like this:

```log
$ bundle exec fluentd --show-plugin-config output:grepcounter -p lib/fluent/plugin/
2015-12-09 11:55:27 +0900 [info]: Show config for output:grepcounter
2015-12-09 11:55:27 +0900 [info]: 
input_key: string: <nil> # The target field key to grep out.
Use with regexp or exclude.

regexp: string: <nil> # The filtering regular expression.
exclude: string: <nil> # The excluding regular expression like grep -v.
regexp1: string: <nil>
regexp2: string: <nil>
regexp3: string: <nil>
regexp4: string: <nil>
regexp5: string: <nil>
regexp6: string: <nil>
regexp7: string: <nil>
regexp8: string: <nil>
regexp9: string: <nil>
regexp10: string: <nil>
regexp11: string: <nil>
regexp12: string: <nil>
regexp13: string: <nil>
regexp14: string: <nil>
regexp15: string: <nil>
regexp16: string: <nil>
regexp17: string: <nil>
regexp18: string: <nil>
regexp19: string: <nil>
regexp20: string: <nil>
exclude1: string: <nil>
exclude2: string: <nil>
exclude3: string: <nil>
exclude4: string: <nil>
exclude5: string: <nil>
exclude6: string: <nil>
exclude7: string: <nil>
exclude8: string: <nil>
exclude9: string: <nil>
exclude10: string: <nil>
exclude11: string: <nil>
exclude12: string: <nil>
exclude13: string: <nil>
exclude14: string: <nil>
exclude15: string: <nil>
exclude16: string: <nil>
exclude17: string: <nil>
exclude18: string: <nil>
exclude19: string: <nil>
exclude20: string: <nil>
count_interval: time: <5> # The interval time to count in seconds.
threshold: integer: <nil> # The threshold number to emit.
Emit if count value >= specified value.
Note that this param is not obsolete.

comparator: string: <">=">
less_than: float: <nil> # Emit if count value is less than (<) specified value.
less_equal: float: <nil> # Emit if count value is less than or equal to (<=) specified value.
greater_than: float: <nil> # Emit if count value is greater than (>) specified value.
greater_equal: float: <nil> # This is same with threshold option.
Emit if count value is greater than or equal to (>=) specified value.

output_tag: string: <nil>
tag: string: <nil> # The output tag. Required for aggregate all.
add_tag_prefix: string: <nil> # Add tag prefix for output message.
remove_tag_prefix: string: <nil> # Remove tag prefix for output message.
add_tag_suffix: string: <nil> # Add tag suffix for output message.
remove_tag_suffix: string: <nil> # Remove tag suffix for output message.
remove_tag_slice: string: <nil> # Remove tag parts by slice function.
Note that this option behaves like tag.split('.').slice(min..max).

output_with_joined_delimiter: string: <nil>
delimiter: string: <nil> # Output matched messages after joined with the specified delimiter.
aggregate: string: <"tag"> # Aggregation unit. One of all, in_tag, out_tag can be specified.
replace_invalid_sequence: bool: <false> # Replace invalid byte sequence in UTF-8 with '?' character if true.
store_file: string: <nil> # Store internal count data into a file of the given path on shutdown, and load on statring.
```

In fluentd 0.12.15 or older, `:desc` has no effect.