### PR TITLE
test: restore router after run to fix specs on fluentd v1.19.3

### DIFF
--- a/spec/out_grepcounter_spec.rb
+++ b/spec/out_grepcounter_spec.rb
@@ -6,6 +6,16 @@ class Fluent::Test::OutputTestDriver
     @tag = tag if tag
     emit(record, time)
   end
+
+  # Since fluentd v1.19.3, TestDriver#run invokes the full shutdown lifecycle
+  # (after_shutdown/close/terminate), each of which resets the plugin's router
+  # to nil. These specs call flush_emit after run, so restore the router to
+  # keep router.emit working.
+  def run(*args, &block)
+    super
+  ensure
+    instance.router = Fluent::Engine.root_agent.event_router
+  end
 end
 
 class Hash


### PR DESCRIPTION
Since fluentd v1.19.3, Fluent::Test::TestDriver#run runs the full shutdown lifecycle (after_shutdown/close/terminate) in its ensure block, and each of those resets the plugin's router to nil in PluginHelper::EventEmitter.
Ref. https://github.com/fluent/fluentd/pull/5324

Our specs call driver.instance.flush_emit after driver.run returns, so router.emit raised "undefined method 'emit' for nil". Override run in the OutputTestDriver monkey-patch to restore the router after teardown.